### PR TITLE
`init`: ignore `puppet-lint` warning on long line in `exec`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,7 +64,7 @@ define patch (
     owner        => $patch::cache::owner,
     group        => $patch::cache::group,
     mode         => $patch::cache::mode,
-    validate_cmd => sprintf('cd %s && /usr/bin/env patch --dry-run %s %s --forward --strip %s < %%', $target, $loose_option, $backup_option, $strip),
+    validate_cmd => sprintf('cd %s && /usr/bin/env patch --dry-run %s %s --forward --strip %s < %%', $target, $loose_option, $backup_option, $strip), # lint:ignore:140chars
   }
 
   -> exec { "${title}.patch":


### PR DESCRIPTION
Includes #1.